### PR TITLE
chore: temporarily use pure Python implementation of `idx_to_signal`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(${SKBUILD_PROJECT_NAME} LANGUAGES C CXX)
 
 find_package(
   Python
-  COMPONENTS Interpreter Development.Module NumPy
+  COMPONENTS Interpreter Development.Module
+  # NumPy
   REQUIRED)
 
 # webpack
@@ -59,24 +60,26 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_compile_definitions(dps PRIVATE CYTHON_TRACE=1 CYTHON_TRACE_NOGIL=1)
 endif()
 
-# utils_np
-add_custom_command(
-  OUTPUT utils_np.c
-  COMMENT
-    "Making ${CMAKE_CURRENT_BINARY_DIR}/utils_np.cpp from ${CMAKE_CURRENT_SOURCE_DIR}/reacnetgenerator/utils_np.pyx"
-  COMMAND
-    Python::Interpreter -m cython
-    "${CMAKE_CURRENT_SOURCE_DIR}/reacnetgenerator/utils_np.pyx" --output-file
-    utils_np.c
-  DEPENDS reacnetgenerator/utils_np.pyx
-  VERBATIM)
+# utils_np temporary disable until limited api is supported
+if(FALSE)
+  add_custom_command(
+    OUTPUT utils_np.c
+    COMMENT
+      "Making ${CMAKE_CURRENT_BINARY_DIR}/utils_np.cpp from ${CMAKE_CURRENT_SOURCE_DIR}/reacnetgenerator/utils_np.pyx"
+    COMMAND
+      Python::Interpreter -m cython
+      "${CMAKE_CURRENT_SOURCE_DIR}/reacnetgenerator/utils_np.pyx" --output-file
+      utils_np.c
+    DEPENDS reacnetgenerator/utils_np.pyx
+    VERBATIM)
 
-python_add_library(utils_np MODULE ${CMAKE_CURRENT_BINARY_DIR}/utils_np.c
-                   WITH_SOABI)
-target_link_libraries(utils_np PRIVATE Python::NumPy)
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_definitions(utils_np PRIVATE CYTHON_TRACE=1
-                                              CYTHON_TRACE_NOGIL=1)
+  python_add_library(utils_np MODULE ${CMAKE_CURRENT_BINARY_DIR}/utils_np.c
+                     WITH_SOABI)
+  target_link_libraries(utils_np PRIVATE Python::NumPy)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(utils_np PRIVATE CYTHON_TRACE=1
+                                                CYTHON_TRACE_NOGIL=1)
+  endif()
+
+  install(TARGETS dps utils_np DESTINATION reacnetgenerator/)
 endif()
-
-install(TARGETS dps utils_np DESTINATION reacnetgenerator/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,6 @@ if(FALSE)
     target_compile_definitions(utils_np PRIVATE CYTHON_TRACE=1
                                                 CYTHON_TRACE_NOGIL=1)
   endif()
-
-  install(TARGETS dps utils_np DESTINATION reacnetgenerator/)
+  install(TARGETS utils_np DESTINATION reacnetgenerator/)
 endif()
+install(TARGETS dps DESTINATION reacnetgenerator/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.9.0",
-    "oldest-supported-numpy; python_version < '3.9'",
+    # "oldest-supported-numpy; python_version < '3.9'",
     "numpy>=2.0.0rc0; python_version >= '3.9'",
     "nodejs-wheel~=20.9",
     "pyyaml",
@@ -40,8 +40,9 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
 ]
 dependencies = [
-    "numpy<2; python_version < '3.9'",
-    "numpy>=1.19,<3; python_version >= '3.9'",
+    # "numpy<2; python_version < '3.9'",
+    # "numpy>=1.19,<3; python_version >= '3.9'",
+    'numpy',
     'networkx',
     'matplotlib',
     'hmmlearn>=0.2.1',

--- a/reacnetgenerator/_hmmfilter.py
+++ b/reacnetgenerator/_hmmfilter.py
@@ -37,11 +37,11 @@ from .utils import (
     appendIfNotNone,
     bytestolist,
     check_zero_signal,
+    idx_to_signal,
     listtobytes,
     read_compressed_block,
     run_mp,
 )
-from .utils_np import idx_to_signal  # type:ignore
 
 
 class _HMMFilter(SharedRNGData):

--- a/reacnetgenerator/utils.py
+++ b/reacnetgenerator/utils.py
@@ -612,3 +612,30 @@ def check_zero_signal(signal: np.ndarray) -> bool:
     # any() doesn't have short-circuits, but argmax() does for bool.
     # See https://stackoverflow.com/a/45774536/9567349
     return signal[signal.argmax()]
+
+
+def idx_to_signal(idx: np.ndarray, step: int):
+    """Convert an index array to a signal array.
+
+    Parameters
+    ----------
+    idx : array_like
+        Index array.
+    step : int
+        Step size.
+
+    Returns
+    -------
+    signal : ndarray
+        Signal array in int8.
+    """
+    # Cython implementation is 1-2x faster than Python implementation.
+    # However, with it, it's hard to use the limited Python API:
+    # (1) https://github.com/cython/cython/issues/5697
+    # (2) memory view limited API only available since python 3.11
+    # when 1 is resolved, we may add back the Cython implementation
+    # for Python 3.11+ only (build two wheels).
+
+    signal = np.zeros(step, dtype=np.int8)
+    signal[idx] = 1
+    return signal.reshape((step, 1))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Modified the build configuration by adjusting `find_package` components and temporarily disabling a section.
    - Removed version constraints for a library in the dependency management file.
- **New Features**
    - Introduced a new function in a utility module to convert index arrays to signal arrays.
- **Bug Fixes**
    - Reorganized functions by moving one to the appropriate module for better module structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->