### PR TITLE
ci(wheel): enable linux aarch64 wheel

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -14,8 +14,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  determine-arm64-runner:
+    runs-on: ubuntu-latest
+    permissions: read-all
+    outputs:
+      runner: ${{ steps.set-runner.outputs.runner }}
+    steps:
+      - name: Determine which runner to use for ARM64 build
+        id: set-runner
+        run: |
+          if [ "${{ github.repository_owner }}" == "deepmodeling" ]; then
+            echo "runner=[\"Linux\",\"ARM64\"]" >> $GITHUB_OUTPUT
+          else
+            echo "runner=\"ubuntu-latest\"" >> $GITHUB_OUTPUT
+          fi
   build_wheels:
     name: Build wheels for cp${{ matrix.python }}-${{ matrix.platform_id }}
+    needs: determine-arm64-runner
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,8 +48,16 @@ jobs:
           - os: windows-2019
             python: 38
             platform_id: win_amd64
+          # linux-aarch64
+          - os: ${{ fromJson(needs.determine-arm64-runner.outputs.runner) }}
+            python: 310
+            platform_id: manylinux_aarch64
+            dp_variant: cpu
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        name: Setup QEMU
+        if: matrix.platform_id == 'manylinux_aarch64' && matrix.os == 'ubuntu-latest'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ test-command = "reacnetgenerator -h"
 build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
 test-skip = "cp37-*"
-before-test = ["""python -m pip install "replace-pip-with-uv-pip; not (platform_system=='Linux' or platform_machine=='aarch64')" """]
+before-test = ["""python -m pip install "replace-pip-with-uv-pip; platform_system!='Linux' or platform_machine!='aarch64'" """]
 
 [tool.cibuildwheel.linux]
 environment-pass = ["CIBW_BUILD"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ test-command = "reacnetgenerator -h"
 build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
 test-skip = "cp37-*"
-before-test = ["python -m pip install replace-pip-with-uv-pip"]
+before-test = ["""python -m pip install "replace-pip-with-uv-pip; not (platform_system=='Linux' or platform_machine=='aarch64')" """]
 
 [tool.cibuildwheel.linux]
 environment-pass = ["CIBW_BUILD"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,8 @@ fallback_version = "Unknown"
 test-command = "reacnetgenerator -h"
 build = ["cp37-*", "cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 skip = ["*-win32", "*-manylinux_i686", "*-musllinux*"]
-test-skip = "cp37-*"
+# wait for openbabel
+test-skip = "cp37-* *-manylinux_aarch64"
 before-test = ["""python -m pip install "replace-pip-with-uv-pip; platform_system!='Linux' or platform_machine!='aarch64'" """]
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Enhanced the build process to automatically select the appropriate runner for ARM64 builds, ensuring compatibility and efficiency in software deployment.
- **Refactor**
	- Added conditions to skip tests for Python 3.7 on the manylinux_aarch64 platform and updated the package installation command based on platform conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->