### PR TITLE
ci: use Python 3.12 for benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         architecture: 'x64'
     - run: pip install uv
     - run: uv pip install --system -e .[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Python version in the benchmark workflow from 3.11 to 3.12 for better compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->