### PR TITLE
chore: bump pyright to 1.1.391

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -20,9 +20,9 @@ jobs:
     - uses: actions/checkout@master
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - run: pip install uv
     - run: uv pip install --system -e .
     - uses: jakebailey/pyright-action@v2
       with:
-        version: 1.1.363
+        version: 1.1.391


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Python version in the workflow configuration to 3.12.
	- Incremented the `pyright-action` version to 1.1.391 for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->