### PR TITLE
fix: fix Mo when O is also contained

### DIFF
--- a/reacnetgenerator/_path.py
+++ b/reacnetgenerator/_path.py
@@ -247,7 +247,7 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
                 if an != "H"
             ]
         )
-        smi = re.sub(r"(?<!\[)(" + elements + r")(?!H)", r"[\1]", smi)
+        smi = re.sub(r"(?<!\[)(" + elements + r")(?!H|\])", r"[\1]", smi)
         return smi.replace("[HH]", "[H]")
 
     def convertSMILES(self, atoms, bonds):

--- a/tests/test_reacnetgen.py
+++ b/tests/test_reacnetgen.py
@@ -152,9 +152,16 @@ class TestReacNetGen:
         """Test regular expression of _HTMLResult."""
         reacnetgen = ReacNetGenerator(**reacnetgen_param["rngparams"])
         r = _CollectSMILESPaths(reacnetgen)
-        r.atomname = ["C", "H", "O", "Na", "Cl"]
+        r.atomname = np.array(["C", "H", "O", "Na", "Cl"])
         assert r._re("C"), "[C]"
         assert r._re("[C]"), "[C]"
         assert r._re("[CH]"), "[CH]"
         assert r._re("Na"), "[Na]"
         assert r._re("[H]c(Cl)C([H])Cl"), "[H][c]([Cl])[C]([H])[Cl]"
+
+    def test_re_mo(self, reacnetgen_param):
+        """Test regular expression of _HTMLResult."""
+        reacnetgen = ReacNetGenerator(**reacnetgen_param["rngparams"])
+        r = _CollectSMILESPaths(reacnetgen)
+        r.atomname = np.array(["Mo", "O"])
+        assert r._re("[Mo]") == "[Mo]"


### PR DESCRIPTION
Fix #2318.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new test method to validate regular expression functionality for specific atom names

- **Bug Fixes**
	- Updated regular expression pattern to improve element wrapping conditions
	- Clarified docstring for `convertSMILES` method to provide better exception context

- **Tests**
	- Modified atom name handling in test cases from list to NumPy array
	- Expanded test coverage for regular expression matching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->