### PR TITLE
ci(pyright): pin rdkit to <2025.03.3

### DIFF
--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: '3.12'
     - run: pip install uv
-    - run: uv pip install --system -e .
+    - run: uv pip install --system -e . 'rdkit<2025.03.3'
     - uses: jakebailey/pyright-action@v2
       with:
         version: 1.1.391


### PR DESCRIPTION
See https://github.com/kuelumbus/rdkit-pypi/issues/132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to restrict the version of the `rdkit` package during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->