### PR TITLE
fix: normalize fallback version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ cmake.version = ">=3.26"
 
 [tool.setuptools_scm]
 write_to = "reacnetgenerator/_version2.py"
-fallback_version = "Unknown"
+fallback_version = "0.0.0"
 
 [tool.cibuildwheel]
 test-command = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the fallback version to “0.0.0” when build metadata isn’t available, replacing the previous “Unknown” label. This provides a clear, semantic version in apps, logs, and package info.
  * Improves consistency across environments by preventing ambiguous “Unknown” version displays. No functional changes to features; only the reported version string is affected when source control metadata cannot be detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->