### PR TITLE
fix: compact Step 3 state storage

### DIFF
--- a/reacnetgenerator/_hmmfilter.py
+++ b/reacnetgenerator/_hmmfilter.py
@@ -102,7 +102,12 @@ class _HMMFilter(SharedRNGData):
         hmmbytes = None
         if self.runHMM:
             hmmsignal = self._model.predict(origin).astype(bool)
-            if check_zero_signal(hmmsignal) or self.printfiltersignal:
+            # Origin output retains metadata even for filtered-out molecules.
+            if (
+                check_zero_signal(hmmsignal)
+                or self.printfiltersignal
+                or self.getoriginfile
+            ):
                 hmmbytes = listtobytes(hmmsignal)
         return originbytes, hmmbytes, line_c
 

--- a/reacnetgenerator/_path.py
+++ b/reacnetgenerator/_path.py
@@ -36,6 +36,11 @@ from rdkit import Chem
 from tqdm.auto import tqdm
 
 from ._reaction import ReactionsFinder
+from ._step3state import (
+    _AtomFrameStore,
+    _MoleculeNameBuilder,
+    _MoleculeNameTable,
+)
 from .utils import (
     SharedRNGData,
     WriteBuffer,
@@ -145,7 +150,7 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
     printmoleculetime: bool
     moleculeframes: list
     moleculetimesteps: list
-    mname: np.ndarray
+    mname: _MoleculeNameTable
     _moleculetimelinebufferrows: int = 10000
 
     def __init__(self, rng):
@@ -197,55 +202,71 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
         """Collect paths."""
         self.atomnames = self.atomname[self.atomtype]
         self._printmoleculename()
-        atomeach, conflict = self._getatomeach()
-        self.allmoleculeroute = self._printatomroute(atomeach)
-        if self.split > 1:
-            splittime = np.array_split(np.arange(self.step), self.split)
-            self.splitmoleculeroute = [
-                self._printatomroute(atomeach[:, st], timeaxis=i)
-                for i, st in enumerate(splittime)
-            ]
-        self.returnkeys()
-        ReactionsFinder(self.rng).findreactions(atomeach.T, conflict.T)
+        matrix_store = self._getatomeach()
+        try:
+            atomeach = matrix_store.atomeach
+            self.allmoleculeroute = self._printatomroute(atomeach)
+            if self.split > 1:
+                splittime = np.array_split(np.arange(self.step), self.split)
+                self.splitmoleculeroute = [
+                    self._printatomroute(atomeach[:, st], timeaxis=i)
+                    for i, st in enumerate(splittime)
+                ]
+            self.returnkeys()
+            ReactionsFinder(self.rng).findreactions(
+                atomeach.T,
+                matrix_store.conflict.T,
+            )
+        finally:
+            matrix_store.close()
 
     @abstractmethod
     def _printmoleculename(self):
         pass
 
     def _getatomeach(self):
-        """Values in atomeach starts from 1."""
-        atomeach = np.zeros((self.N, self.step), dtype=int)
-        conflict = np.zeros((self.N, self.step), dtype=int)
-        with (
-            open(self.hmmfilename if self.runHMM else self.originfilename, "rb") as fh,
-            open(self.moleculetemp2filename, "rb") as ft,
-        ):
-            for i, (linehz, linetz) in enumerate(
-                tqdm(
-                    zip(
-                        read_compressed_block(fh),
-                        itertools.zip_longest(*[read_compressed_block(ft)] * 4),
-                    ),
-                    total=self.hmmit,
-                    desc="Analyze atoms",
-                    unit="molecule",
-                    disable=None,
-                ),
-                start=1,
+        """Build compact atom-frame matrices; molecule IDs start from 1."""
+        store = _AtomFrameStore((self.N, self.step), self.hmmit)
+        try:
+            with (
+                open(
+                    self.hmmfilename if self.runHMM else self.originfilename,
+                    "rb",
+                ) as fh,
+                open(self.moleculetemp2filename, "rb") as ft,
             ):
-                lineh = bytestolist(linehz)
-                atom = np.array(bytestolist(linetz[0]))
-                index = np.where(lineh)[0]
-                if index.size:
-                    # ``np.nonzero`` reports coordinates relative to this sliced
-                    # molecule/timestep grid. Map them back to the full atom and
-                    # timestep axes before recording conflicts.
-                    conflict_atom, conflict_step = np.nonzero(
-                        atomeach[atom[:, None], index]
-                    )
-                    conflict[atom[conflict_atom], index[conflict_step]] = 1
-                    atomeach[atom[:, None], index] = i
-        return atomeach, conflict
+                for molecule_id, (linehz, linetz) in enumerate(
+                    tqdm(
+                        zip(
+                            read_compressed_block(fh),
+                            itertools.zip_longest(*[read_compressed_block(ft)] * 4),
+                        ),
+                        total=self.hmmit,
+                        desc="Analyze atoms",
+                        unit="molecule",
+                        disable=None,
+                    ),
+                    start=1,
+                ):
+                    if molecule_id > self.hmmit:
+                        raise RuntimeError(
+                            "More molecule records than the declared count"
+                        )
+                    lineh = bytestolist(linehz)
+                    atoms = np.asarray(bytestolist(linetz[0]), dtype=np.int64)
+                    frames = np.flatnonzero(lineh)
+                    if frames.size:
+                        overlap = np.not_equal(
+                            store.atomeach[atoms[:, None], frames],
+                            0,
+                        )
+                        store.conflict.mark(atoms, frames, overlap)
+                        store.atomeach[atoms[:, None], frames] = molecule_id
+            store.flush()
+            return store
+        except BaseException:
+            store.close()
+            raise
 
     def _getatomroute(self, item):
         i, (atomeachi, atomtypei) = item
@@ -485,7 +506,7 @@ class _CollectMolPaths(_CollectPaths):
     """
 
     def _printmoleculename(self):
-        mname = []
+        mname = _MoleculeNameBuilder(self.hmmit)
         d = defaultdict(list)
         em = iso.numerical_edge_match(["atom", "level"], ["None", 1])
         # idx for unknown SMILES
@@ -533,12 +554,12 @@ class _CollectMolPaths(_CollectPaths):
         finally:
             if timeline is not None:
                 timeline.close()
-        self.mname = np.array(mname)
+        self.mname = mname.finish()
 
 
 class _CollectSMILESPaths(_CollectPaths):
     def _printmoleculename(self):
-        mname = []
+        mname = _MoleculeNameBuilder(self.hmmit)
         d = defaultdict(list)
         name_mapping = {}
         name_mapping_graph = defaultdict(dict)
@@ -612,7 +633,7 @@ class _CollectSMILESPaths(_CollectPaths):
         finally:
             if timeline is not None:
                 timeline.close()
-        self.mname = np.array(mname)
+        self.mname = mname.finish()
 
     def _calmoleculeSMILESname(self, item):
         line = item

--- a/reacnetgenerator/_path.py
+++ b/reacnetgenerator/_path.py
@@ -202,8 +202,7 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
         """Collect paths."""
         self.atomnames = self.atomname[self.atomtype]
         self._printmoleculename()
-        matrix_store = self._getatomeach()
-        try:
+        with self._getatomeach() as matrix_store:
             atomeach = matrix_store.atomeach
             self.allmoleculeroute = self._printatomroute(atomeach)
             if self.split > 1:
@@ -217,8 +216,6 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
                 atomeach.T,
                 matrix_store.conflict.T,
             )
-        finally:
-            matrix_store.close()
 
     @abstractmethod
     def _printmoleculename(self):
@@ -226,7 +223,11 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
 
     def _getatomeach(self):
         """Build compact atom-frame matrices; molecule IDs start from 1."""
-        store = _AtomFrameStore((self.N, self.step), self.hmmit)
+        store = _AtomFrameStore(
+            (self.N, self.step),
+            self.hmmit,
+            directory=os.path.dirname(os.path.abspath(self.atomroutefilename)),
+        )
         try:
             with (
                 open(
@@ -240,6 +241,7 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
                         zip(
                             read_compressed_block(fh),
                             itertools.zip_longest(*[read_compressed_block(ft)] * 4),
+                            strict=True,
                         ),
                         total=self.hmmit,
                         desc="Analyze atoms",

--- a/reacnetgenerator/_path.py
+++ b/reacnetgenerator/_path.py
@@ -223,11 +223,15 @@ class _CollectPaths(SharedRNGData, metaclass=ABCMeta):
 
     def _getatomeach(self):
         """Build compact atom-frame matrices; molecule IDs start from 1."""
-        store = _AtomFrameStore(
-            (self.N, self.step),
-            self.hmmit,
-            directory=os.path.dirname(os.path.abspath(self.atomroutefilename)),
-        )
+        try:
+            store = _AtomFrameStore(
+                (self.N, self.step),
+                self.hmmit,
+                directory=os.path.dirname(os.path.abspath(self.atomroutefilename)),
+            )
+        except PermissionError:
+            # Writable outputs such as /dev/null can have unwritable parents.
+            store = _AtomFrameStore((self.N, self.step), self.hmmit)
         try:
             with (
                 open(

--- a/reacnetgenerator/_step3state.py
+++ b/reacnetgenerator/_step3state.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import operator
 import os
 import tempfile
+from contextlib import suppress
 from typing import Literal
 
 import numpy as np
@@ -287,10 +288,8 @@ class _PackedBoolMatrix:
                 if mmap is not None:
                     mmap.close()
         finally:
-            try:
+            with suppress(FileNotFoundError):
                 os.unlink(self.path)
-            except FileNotFoundError:
-                pass
 
 
 class _AtomFrameStore:
@@ -333,10 +332,8 @@ class _AtomFrameStore:
             if conflict is not None:
                 conflict.close()
             for path in (self.atomeach_path, conflict_path):
-                try:
+                with suppress(FileNotFoundError):
                     os.unlink(path)
-                except FileNotFoundError:
-                    pass
             self._closed = True
             raise
 
@@ -364,9 +361,8 @@ class _AtomFrameStore:
                     mmap.close()
         finally:
             try:
-                os.unlink(self.atomeach_path)
-            except FileNotFoundError:
-                pass
+                with suppress(FileNotFoundError):
+                    os.unlink(self.atomeach_path)
             finally:
                 self.conflict.close()
 
@@ -377,7 +373,5 @@ class _AtomFrameStore:
         self.close()
 
     def __del__(self):
-        try:
+        with suppress(Exception):
             self.close()
-        except BaseException:
-            pass

--- a/reacnetgenerator/_step3state.py
+++ b/reacnetgenerator/_step3state.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Compact temporary state used while collecting reaction paths."""
+
+from __future__ import annotations
+
+import operator
+import os
+import tempfile
+from typing import Literal
+
+import numpy as np
+
+_PACKED_BOOL_SPARSE_SELECTION_DIVISOR = 8
+
+
+def _unsigned_dtype_for_maximum(maximum_value: int) -> np.dtype:
+    """Return the narrowest unsigned dtype containing ``maximum_value``."""
+    maximum = max(0, int(maximum_value))
+    for dtype in (np.uint8, np.uint16, np.uint32, np.uint64):
+        if maximum <= np.iinfo(dtype).max:
+            return np.dtype(dtype)
+    raise OverflowError("Value exceeds unsigned 64-bit integer storage")
+
+
+class _MoleculeNameTable:
+    """Map each molecule ID to one deduplicated species name."""
+
+    def __init__(self, ids, names, *, validate: bool = True) -> None:
+        self.ids = np.asarray(ids)
+        self.names = np.asarray(names)
+        if self.ids.ndim != 1 or self.names.ndim != 1:
+            raise ValueError("Molecule name IDs and values must be one-dimensional")
+        if not np.issubdtype(self.ids.dtype, np.unsignedinteger):
+            raise TypeError("Molecule name IDs must use an unsigned integer dtype")
+        if validate and self.ids.size and int(self.ids.max()) >= len(self.names):
+            raise ValueError("Molecule name ID is outside the species-name table")
+
+    @classmethod
+    def from_names(cls, values):
+        """Build a compact table from an iterable of molecule names."""
+        values = list(values)
+        builder = _MoleculeNameBuilder(len(values))
+        for value in values:
+            builder.append(value)
+        return builder.finish()
+
+    def __len__(self) -> int:
+        return len(self.ids)
+
+    def __iter__(self):
+        return (self.names[int(name_id)] for name_id in self.ids)
+
+    def __getitem__(self, index):
+        return self.names[self.ids[index]]
+
+    def __array__(self, dtype=None, copy=None):
+        values = self.names[self.ids]
+        if dtype is not None:
+            values = values.astype(dtype, copy=False)
+        if copy:
+            values = values.copy()
+        return values
+
+
+class _MoleculeNameBuilder:
+    """Build a fixed-size name table without retaining duplicate strings."""
+
+    def __init__(self, molecule_count: int) -> None:
+        molecule_count = int(molecule_count)
+        if molecule_count < 0:
+            raise ValueError("Molecule count must be non-negative")
+        self.ids = np.empty(
+            molecule_count,
+            dtype=_unsigned_dtype_for_maximum(max(0, molecule_count - 1)),
+        )
+        self.names: list[str] = []
+        self._name_ids: dict[str, int] = {}
+        self._count = 0
+
+    def append(self, name: str) -> None:
+        """Append one molecule name in molecule-ID order."""
+        if self._count >= len(self.ids):
+            raise RuntimeError("More molecule names than the declared count")
+        name = str(name)
+        name_id = self._name_ids.get(name)
+        if name_id is None:
+            name_id = len(self.names)
+            self._name_ids[name] = name_id
+            self.names.append(name)
+        self.ids[self._count] = name_id
+        self._count += 1
+
+    def finish(self) -> _MoleculeNameTable:
+        """Return the completed compact table."""
+        if self._count != len(self.ids):
+            raise RuntimeError("Fewer molecule names than the declared count")
+        names = np.asarray(self.names, dtype=str)
+        target_dtype = _unsigned_dtype_for_maximum(max(0, len(names) - 1))
+        ids = (
+            self.ids
+            if self.ids.dtype == target_dtype
+            else self.ids.astype(target_dtype)
+        )
+        return _MoleculeNameTable(ids, names, validate=False)
+
+
+def _is_full_slice(index) -> bool:
+    return (
+        isinstance(index, slice)
+        and index.start is None
+        and index.stop is None
+        and index.step is None
+    )
+
+
+class _PackedBoolFrameView:
+    """Expose packed atom-by-frame data as a lazy frame-by-atom view."""
+
+    def __init__(self, matrix: _PackedBoolMatrix, frames=None) -> None:
+        self._matrix = matrix
+        self._frames = range(matrix.shape[1]) if frames is None else frames
+        self.shape = (len(self._frames), matrix.shape[0])
+        self.dtype = np.dtype(np.bool_)
+
+    def __len__(self) -> int:
+        return len(self._frames)
+
+    def __iter__(self):
+        for frame in self._frames:
+            yield self._matrix._read_column(frame, slice(None))
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return _PackedBoolFrameView(self._matrix, self._frames[index])
+        frame = self._frames[operator.index(index)]
+        return self._matrix._read_column(frame, slice(None))
+
+    def __array__(self, dtype=None, copy=None):
+        if len(self) == 0:
+            values = np.empty(self.shape, dtype=np.bool_)
+        else:
+            values = np.stack(tuple(self), axis=0)
+        if dtype is not None:
+            values = values.astype(dtype, copy=False)
+        if copy:
+            values = values.copy()
+        return values
+
+
+class _PackedBoolMatrix:
+    """Store a logical row-major boolean matrix using one bit per cell."""
+
+    def __init__(
+        self,
+        path: str,
+        shape,
+        *,
+        mode: Literal["r", "r+", "w+", "c"] = "w+",
+    ) -> None:
+        self.path = path
+        self.shape = tuple(int(value) for value in shape)
+        if len(self.shape) != 2 or min(self.shape) <= 0:
+            raise ValueError("Packed boolean matrix shape must be two positive values")
+        self.dtype = np.dtype(np.bool_)
+        self.packed_shape = (self.shape[0], (self.shape[1] + 7) // 8)
+        self.data = np.memmap(
+            path,
+            mode=mode,
+            dtype=np.uint8,
+            shape=self.packed_shape,
+        )
+        if mode.startswith("w"):
+            self.data.fill(0)
+        self._closed = False
+
+    @property
+    def T(self) -> _PackedBoolFrameView:
+        """Return a lazy frame-by-atom transpose view."""
+        return _PackedBoolFrameView(self)
+
+    @property
+    def nbytes(self) -> int:
+        """Return the size of the packed payload in bytes."""
+        return int(np.prod(self.packed_shape, dtype=np.int64))
+
+    def __len__(self) -> int:
+        return self.shape[0]
+
+    def _read_column(self, column, rows):
+        column = operator.index(column)
+        if column < 0:
+            column += self.shape[1]
+        if column < 0 or column >= self.shape[1]:
+            raise IndexError("Packed boolean matrix column is out of range")
+        values = self.data[rows, column // 8]
+        return np.not_equal(
+            np.bitwise_and(values, np.uint8(1 << (column % 8))),
+            0,
+        )
+
+    def _unpack_rows(self, rows):
+        packed = np.asarray(self.data[rows])
+        values = np.unpackbits(packed, axis=-1, bitorder="little")
+        return values[..., : self.shape[1]].astype(np.bool_, copy=False)
+
+    def __getitem__(self, index):
+        if isinstance(index, tuple):
+            if len(index) != 2:
+                raise IndexError("Packed boolean matrix requires two indices")
+            rows, columns = index
+            try:
+                column = operator.index(columns)
+            except TypeError:
+                values = self._unpack_rows(rows)
+                return values[..., columns]
+            return self._read_column(column, rows)
+        return self._unpack_rows(index)
+
+    def __setitem__(self, index, value) -> None:
+        if not _is_full_slice(index):
+            raise TypeError("Packed boolean matrix only supports whole-matrix fill")
+        if not np.isscalar(value):
+            raise TypeError("Packed boolean matrix fill value must be a scalar")
+        self.data.fill(255 if bool(value) else 0)
+        if value and self.shape[1] % 8:
+            self.data[:, -1] &= np.uint8((1 << (self.shape[1] % 8)) - 1)
+
+    def __array__(self, dtype=None, copy=None):
+        values = self._unpack_rows(slice(None))
+        if dtype is not None:
+            values = values.astype(dtype, copy=False)
+        if copy:
+            values = values.copy()
+        return values
+
+    def mark(self, atoms, frames, overlap) -> None:
+        """Set cells selected by an atom-by-frame overlap mask."""
+        atoms = np.asarray(atoms, dtype=np.int64).reshape((-1,))
+        frames = np.asarray(frames, dtype=np.int64).reshape((-1,))
+        overlap = np.asarray(overlap, dtype=np.bool_)
+        if overlap.shape != (len(atoms), len(frames)):
+            raise ValueError("Conflict overlap shape does not match selected cells")
+        if len(atoms) == 0 or len(frames) == 0:
+            return
+        if np.any((frames < 0) | (frames >= self.shape[1])):
+            raise IndexError("Packed boolean matrix frame is out of range")
+        active_count = int(np.count_nonzero(overlap))
+        if active_count == 0:
+            return
+        if active_count * _PACKED_BOOL_SPARSE_SELECTION_DIVISOR <= overlap.size:
+            active_positions = np.flatnonzero(overlap)
+            atom_positions, frame_positions = np.divmod(
+                active_positions,
+                len(frames),
+            )
+            selected_frames = frames[frame_positions]
+            np.bitwise_or.at(
+                self.data,
+                (atoms[atom_positions], selected_frames // 8),
+                np.asarray(1 << (selected_frames % 8), dtype=np.uint8),
+            )
+            return
+        bit_masks = np.asarray(1 << (frames % 8), dtype=np.uint8)
+        write_masks = overlap.view(np.uint8).copy()
+        np.multiply(write_masks, bit_masks, out=write_masks)
+        np.bitwise_or.at(
+            self.data,
+            (atoms[:, np.newaxis], (frames // 8)[np.newaxis, :]),
+            write_masks,
+        )
+
+    def flush(self) -> None:
+        """Flush the packed mapping to its temporary file."""
+        if not self._closed:
+            self.data.flush()
+
+    def close(self) -> None:
+        """Close the mapping and remove its temporary file."""
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            try:
+                self.data.flush()
+            finally:
+                mmap = getattr(self.data, "_mmap", None)
+                if mmap is not None:
+                    mmap.close()
+        finally:
+            try:
+                os.unlink(self.path)
+            except FileNotFoundError:
+                pass
+
+
+class _AtomFrameStore:
+    """Own compact disk-backed atom-by-frame matrices for Step 3."""
+
+    def __init__(self, shape, maximum_molecule_id: int, *, directory=None) -> None:
+        self.shape = tuple(int(value) for value in shape)
+        if len(self.shape) != 2 or min(self.shape) <= 0:
+            raise ValueError("Atom-frame matrix shape must be two positive values")
+        self.molecule_dtype = _unsigned_dtype_for_maximum(maximum_molecule_id)
+        atom_handle, self.atomeach_path = tempfile.mkstemp(
+            prefix="reacnetgenerator-atomeach-",
+            suffix=".mmap",
+            dir=directory,
+        )
+        os.close(atom_handle)
+        conflict_handle, conflict_path = tempfile.mkstemp(
+            prefix="reacnetgenerator-conflict-",
+            suffix=".mmap",
+            dir=directory,
+        )
+        os.close(conflict_handle)
+        try:
+            self.atomeach = np.memmap(
+                self.atomeach_path,
+                mode="w+",
+                dtype=self.molecule_dtype,
+                shape=self.shape,
+            )
+            self.atomeach.fill(0)
+            self.conflict = _PackedBoolMatrix(conflict_path, self.shape)
+            self._closed = False
+        except BaseException:
+            atomeach = getattr(self, "atomeach", None)
+            if atomeach is not None:
+                mmap = getattr(atomeach, "_mmap", None)
+                if mmap is not None:
+                    mmap.close()
+            conflict = getattr(self, "conflict", None)
+            if conflict is not None:
+                conflict.close()
+            for path in (self.atomeach_path, conflict_path):
+                try:
+                    os.unlink(path)
+                except FileNotFoundError:
+                    pass
+            self._closed = True
+            raise
+
+    @property
+    def nbytes(self) -> int:
+        """Return the total disk-backed payload size in bytes."""
+        return int(self.atomeach.nbytes) + self.conflict.nbytes
+
+    def flush(self) -> None:
+        """Flush both mappings before they are consumed."""
+        self.atomeach.flush()
+        self.conflict.flush()
+
+    def close(self) -> None:
+        """Close both mappings and remove their temporary files."""
+        if getattr(self, "_closed", False):
+            return
+        self._closed = True
+        try:
+            try:
+                self.atomeach.flush()
+            finally:
+                mmap = getattr(self.atomeach, "_mmap", None)
+                if mmap is not None:
+                    mmap.close()
+        finally:
+            try:
+                os.unlink(self.atomeach_path)
+            except FileNotFoundError:
+                pass
+            finally:
+                self.conflict.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
+    def __del__(self):
+        try:
+            self.close()
+        except BaseException:
+            pass

--- a/reacnetgenerator/_step3state.py
+++ b/reacnetgenerator/_step3state.py
@@ -300,19 +300,27 @@ class _AtomFrameStore:
         if len(self.shape) != 2 or min(self.shape) <= 0:
             raise ValueError("Atom-frame matrix shape must be two positive values")
         self.molecule_dtype = _unsigned_dtype_for_maximum(maximum_molecule_id)
-        atom_handle, self.atomeach_path = tempfile.mkstemp(
-            prefix="reacnetgenerator-atomeach-",
-            suffix=".mmap",
-            dir=directory,
-        )
-        os.close(atom_handle)
-        conflict_handle, conflict_path = tempfile.mkstemp(
-            prefix="reacnetgenerator-conflict-",
-            suffix=".mmap",
-            dir=directory,
-        )
-        os.close(conflict_handle)
+        self._closed = True
+        atom_handle = None
+        conflict_handle = None
+        atomeach_path = None
+        conflict_path = None
         try:
+            atom_handle, atomeach_path = tempfile.mkstemp(
+                prefix="reacnetgenerator-atomeach-",
+                suffix=".mmap",
+                dir=directory,
+            )
+            os.close(atom_handle)
+            atom_handle = None
+            conflict_handle, conflict_path = tempfile.mkstemp(
+                prefix="reacnetgenerator-conflict-",
+                suffix=".mmap",
+                dir=directory,
+            )
+            os.close(conflict_handle)
+            conflict_handle = None
+            self.atomeach_path = atomeach_path
             self.atomeach = np.memmap(
                 self.atomeach_path,
                 mode="w+",
@@ -323,6 +331,10 @@ class _AtomFrameStore:
             self.conflict = _PackedBoolMatrix(conflict_path, self.shape)
             self._closed = False
         except BaseException:
+            for handle in (atom_handle, conflict_handle):
+                if handle is not None:
+                    with suppress(OSError):
+                        os.close(handle)
             atomeach = getattr(self, "atomeach", None)
             if atomeach is not None:
                 mmap = getattr(atomeach, "_mmap", None)
@@ -331,10 +343,11 @@ class _AtomFrameStore:
             conflict = getattr(self, "conflict", None)
             if conflict is not None:
                 conflict.close()
-            for path in (self.atomeach_path, conflict_path):
+            for path in (atomeach_path, conflict_path):
+                if path is None:
+                    continue
                 with suppress(FileNotFoundError):
                     os.unlink(path)
-            self._closed = True
             raise
 
     @property

--- a/reacnetgenerator/_step3state.py
+++ b/reacnetgenerator/_step3state.py
@@ -95,7 +95,7 @@ class _MoleculeNameBuilder:
         """Return the completed compact table."""
         if self._count != len(self.ids):
             raise RuntimeError("Fewer molecule names than the declared count")
-        names = np.asarray(self.names, dtype=str)
+        names = np.asarray(self.names, dtype=object)
         target_dtype = _unsigned_dtype_for_maximum(max(0, len(names) - 1))
         ids = (
             self.ids

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -50,7 +50,7 @@ class TestRunItems:
         rng.run_items(["species", "reactions"])
         assert os.path.exists(rng.speciesfilename)
         assert os.path.exists(rng.reactionfilename)
-        assert rng.mname.dtype == object
+        assert rng.mname.names.dtype == object
 
     def test_smiles_molecule_names_use_object_dtype(self):
         """SMILES names should not expand to the longest fixed-width string."""
@@ -63,7 +63,7 @@ class TestRunItems:
             nproc=1,
         )
         rng.run_items(["species", "reactions"])
-        assert rng.mname.dtype == object
+        assert rng.mname.names.dtype == object
 
     def test_explicit_species_overrides_legacy_flag_for_one_run(self, rng):
         """Honor a requested species file and then restore caller configuration."""

--- a/tests/test_reacnetgen.py
+++ b/tests/test_reacnetgen.py
@@ -20,6 +20,7 @@ from reacnetgenerator._detect import _Detect
 from reacnetgenerator._hmmfilter import _HMMFilter
 from reacnetgenerator._path import _CollectSMILESPaths, _MoleculeTimelineSpool
 from reacnetgenerator._reaction import ReactionsFinder
+from reacnetgenerator._step3state import _AtomFrameStore
 from reacnetgenerator.commandline import parm2cmd
 from reacnetgenerator.gui import GUI
 from reacnetgenerator.utils import (
@@ -207,14 +208,24 @@ class TestReacNetGen:
         collector.moleculetemp2filename = str(molecule_file)
         collector.hmmit = 2
 
-        atomeach, conflict = collector._getatomeach()
+        store = collector._getatomeach()
+        atomeach_path = store.atomeach_path
+        conflict_path = store.conflict.path
+        try:
+            expected_atomeach = np.zeros((5, 5), dtype=np.uint8)
+            expected_atomeach[2, 3] = 2
+            expected_conflict = np.zeros((5, 5), dtype=np.bool_)
+            expected_conflict[2, 3] = True
+            assert isinstance(store.atomeach, np.memmap)
+            assert store.atomeach.dtype == np.dtype(np.uint8)
+            assert store.conflict.nbytes == 5
+            np.testing.assert_array_equal(store.atomeach, expected_atomeach)
+            np.testing.assert_array_equal(store.conflict, expected_conflict)
+        finally:
+            store.close()
 
-        expected_atomeach = np.zeros((5, 5), dtype=int)
-        expected_atomeach[2, 3] = 2
-        expected_conflict = np.zeros((5, 5), dtype=int)
-        expected_conflict[2, 3] = 1
-        np.testing.assert_array_equal(atomeach, expected_atomeach)
-        np.testing.assert_array_equal(conflict, expected_conflict)
+        assert not os.path.exists(atomeach_path)
+        assert not os.path.exists(conflict_path)
 
     def test_reaction_event_details(self, tmp_path):
         """Single reaction events should expose time-resolved CSV fields."""
@@ -264,6 +275,36 @@ class TestReacNetGen:
             np.array([[1, 1, 2, 2], [3, 3, 3, 3]]),
             np.zeros((2, 4), dtype=int),
         )
+
+        assert event_file.read_text().splitlines() == [
+            "Timestep_Index,Reactant,Product",
+            "0,A+B,C",
+        ]
+
+    def test_reaction_event_accepts_compact_frame_store(self, tmp_path):
+        """Packed conflict columns should preserve ordered reaction events."""
+        event_file = tmp_path / "out.reactionevent.csv"
+        finder = ReactionsFinder(
+            SimpleNamespace(
+                step=2,
+                mname=np.array(["A", "B", "C"]),
+                reactionabcdfilename=str(tmp_path / "out.reactionabcd"),
+                reactioneventfilename=str(event_file),
+                printreactionevent=True,
+                nproc=1,
+            )
+        )
+        with _AtomFrameStore((4, 2), 3, directory=tmp_path) as store:
+            store.atomeach[:] = np.array(
+                [
+                    [1, 3],
+                    [1, 3],
+                    [2, 3],
+                    [2, 3],
+                ]
+            )
+            store.flush()
+            finder.findreactions(store.atomeach.T, store.conflict.T)
 
         assert event_file.read_text().splitlines() == [
             "Timestep_Index,Reactant,Product",

--- a/tests/test_reacnetgen.py
+++ b/tests/test_reacnetgen.py
@@ -206,6 +206,7 @@ class TestReacNetGen:
         collector.originfilename = str(tmp_path / "unused-origin.bin")
         collector.hmmfilename = str(hmm_file)
         collector.moleculetemp2filename = str(molecule_file)
+        collector.atomroutefilename = str(tmp_path / "out.atomroute")
         collector.hmmit = 2
 
         store = collector._getatomeach()
@@ -219,6 +220,8 @@ class TestReacNetGen:
             assert isinstance(store.atomeach, np.memmap)
             assert store.atomeach.dtype == np.dtype(np.uint8)
             assert store.conflict.nbytes == 5
+            assert os.path.dirname(atomeach_path) == str(tmp_path)
+            assert os.path.dirname(conflict_path) == str(tmp_path)
             np.testing.assert_array_equal(store.atomeach, expected_atomeach)
             np.testing.assert_array_equal(store.conflict, expected_conflict)
         finally:
@@ -226,6 +229,34 @@ class TestReacNetGen:
 
         assert not os.path.exists(atomeach_path)
         assert not os.path.exists(conflict_path)
+
+    def test_getatomeach_rejects_mismatched_record_streams(self, tmp_path):
+        """Step 3 should reject rather than truncate unequal record streams."""
+        hmm_file = tmp_path / "hmm.bin"
+        molecule_file = tmp_path / "molecules.bin"
+
+        with open(hmm_file, "wb") as hmm:
+            hmm.write(listtobytes(np.array([True])))
+        with open(molecule_file, "wb") as molecules:
+            for atom in (0, 1):
+                molecules.write(listtobytes(np.array([atom])))
+                for value in ([], [], []):
+                    molecules.write(listtobytes(value))
+
+        collector = object.__new__(_CollectSMILESPaths)
+        collector.N = 2
+        collector.step = 1
+        collector.runHMM = True
+        collector.originfilename = str(tmp_path / "unused-origin.bin")
+        collector.hmmfilename = str(hmm_file)
+        collector.moleculetemp2filename = str(molecule_file)
+        collector.atomroutefilename = str(tmp_path / "out.atomroute")
+        collector.hmmit = 2
+
+        with pytest.raises(ValueError, match="zip"):
+            collector._getatomeach()
+
+        assert not list(tmp_path.glob("reacnetgenerator-*.mmap"))
 
     def test_reaction_event_details(self, tmp_path):
         """Single reaction events should expose time-resolved CSV fields."""
@@ -310,6 +341,42 @@ class TestReacNetGen:
             "Timestep_Index,Reactant,Product",
             "0,A+B,C",
         ]
+
+    def test_reaction_event_honors_packed_conflict(self, tmp_path):
+        """A set packed conflict bit should suppress the affected reaction."""
+        event_file = tmp_path / "out.reactionevent.csv"
+        reaction_file = tmp_path / "out.reactionabcd"
+        finder = ReactionsFinder(
+            SimpleNamespace(
+                step=2,
+                mname=np.array(["A", "B", "C"]),
+                reactionabcdfilename=str(reaction_file),
+                reactioneventfilename=str(event_file),
+                printreactionevent=True,
+                nproc=1,
+            )
+        )
+        with _AtomFrameStore((4, 2), 3, directory=tmp_path) as store:
+            store.atomeach[:] = np.array(
+                [
+                    [1, 3],
+                    [1, 3],
+                    [2, 3],
+                    [2, 3],
+                ]
+            )
+            store.conflict.mark(
+                np.array([0]),
+                np.array([0]),
+                np.array([[True]]),
+            )
+            store.flush()
+            finder.findreactions(store.atomeach.T, store.conflict.T)
+
+        assert event_file.read_text().splitlines() == [
+            "Timestep_Index,Reactant,Product"
+        ]
+        assert reaction_file.read_text() == ""
 
     def test_reaction_event_default_is_off(self, tmp_path):
         """Reaction event details should not be calculated unless requested."""

--- a/tests/test_step3_compatibility.py
+++ b/tests/test_step3_compatibility.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Regression tests for Step 3 signal alignment and scratch storage."""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from reacnetgenerator import ReacNetGenerator
+from reacnetgenerator._path import _CollectSMILESPaths
+from reacnetgenerator.utils import listtobytes
+
+
+def test_hmm_origin_output_preserves_reactions(tmp_path):
+    """Keeping origin signals must not misalign filtered molecule records."""
+    results = []
+    molecule_counts = []
+    for getoriginfile in (False, True):
+        directory = tmp_path / str(getoriginfile)
+        directory.mkdir()
+        input_path = directory / "reaction.bond"
+        shutil.copyfile(Path(__file__).parent / "inputs/reaction.bond", input_path)
+        rng = ReacNetGenerator(
+            inputfilename=str(input_path),
+            inputfiletype="lammpsbondfile",
+            atomname=["H", "O"],
+            nproc=1,
+            runHMM=True,
+            getoriginfile=getoriginfile,
+            printfiltersignal=False,
+        )
+        rng.run()
+        molecule_counts.append(rng.hmmit)
+        results.append(
+            (
+                Path(rng.atomroutefilename).read_bytes(),
+                Path(rng.reactionfilename).read_bytes(),
+                Path(rng.reactionabcdfilename).read_bytes(),
+            )
+        )
+        assert not list(directory.glob("reacnetgenerator-*.mmap"))
+
+    # The fixture must include filtered molecules to exercise missing records.
+    assert molecule_counts[1] > molecule_counts[0]
+    assert results[1] == results[0]
+
+
+@pytest.mark.parametrize("failed_allocation", [1, 2])
+def test_discarded_atom_routes_use_scratch_fallback(
+    tmp_path, monkeypatch, failed_allocation
+):
+    """Unwritable output parents must allow fallback without leaking files."""
+    molecule_file = tmp_path / "molecules.bin"
+    molecule_file.write_bytes(
+        b"".join(listtobytes(value) for value in ([0], [], [], []))
+    )
+    hmm_file = tmp_path / "hmm.bin"
+    hmm_file.write_bytes(listtobytes(np.array([True, False])))
+
+    collector = object.__new__(_CollectSMILESPaths)
+    collector.N = 1
+    collector.step = 2
+    collector.hmmit = 1
+    collector.runHMM = True
+    collector.hmmfilename = str(hmm_file)
+    collector.moleculetemp2filename = str(molecule_file)
+    collector.atomroutefilename = os.devnull
+
+    preferred = tmp_path / "preferred"
+    fallback = tmp_path / "fallback"
+    preferred.mkdir()
+    fallback.mkdir()
+    original_mkstemp = tempfile.mkstemp
+    preferred_attempts = 0
+
+    def allocate(*args, **kwargs):
+        nonlocal preferred_attempts
+        if kwargs.get("dir") is not None:
+            assert kwargs["dir"] == os.path.dirname(os.path.abspath(os.devnull))
+            preferred_attempts += 1
+            if preferred_attempts == failed_allocation:
+                raise PermissionError("simulated unwritable output parent")
+            kwargs["dir"] = preferred
+        else:
+            kwargs["dir"] = fallback
+        return original_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr("reacnetgenerator._step3state.tempfile.mkstemp", allocate)
+
+    with collector._getatomeach() as store:
+        np.testing.assert_array_equal(store.atomeach, [[1, 0]])
+        np.testing.assert_array_equal(store.conflict, [[False, False]])
+        assert Path(store.atomeach_path).parent == fallback
+        assert Path(store.conflict.path).parent == fallback
+        assert not list(preferred.iterdir())
+
+    assert preferred_attempts == failed_allocation
+    assert not list(fallback.iterdir())

--- a/tests/test_step3state.py
+++ b/tests/test_step3state.py
@@ -99,3 +99,15 @@ def test_atom_frame_store_is_compact_transposable_and_recoverable(tmp_path):
 
     assert not os.path.exists(atomeach_path)
     assert not os.path.exists(conflict_path)
+
+
+def test_packed_conflict_marks_sparse_selection(tmp_path):
+    """Sparse overlap masks should mark only their selected cells."""
+    with _AtomFrameStore((3, 10), 4, directory=tmp_path) as store:
+        overlap = np.zeros((3, 10), dtype=np.bool_)
+        overlap[2, 9] = True
+        store.conflict.mark(np.arange(3), np.arange(10), overlap)
+
+        expected = np.zeros((3, 10), dtype=np.bool_)
+        expected[2, 9] = True
+        np.testing.assert_array_equal(store.conflict, expected)

--- a/tests/test_step3state.py
+++ b/tests/test_step3state.py
@@ -2,6 +2,7 @@
 """Test compact temporary state used by Step 3."""
 
 import os
+import tempfile
 
 import numpy as np
 import pytest
@@ -111,3 +112,33 @@ def test_packed_conflict_marks_sparse_selection(tmp_path):
         expected = np.zeros((3, 10), dtype=np.bool_)
         expected[2, 9] = True
         np.testing.assert_array_equal(store.conflict, expected)
+
+
+def test_atom_frame_store_cleans_up_after_second_allocation_failure(
+    tmp_path, monkeypatch
+):
+    """A failed conflict allocation should remove the atom mapping file."""
+    original_mkstemp = tempfile.mkstemp
+    created_paths = []
+    allocation_count = 0
+
+    def fail_second_mkstemp(*args, **kwargs):
+        nonlocal allocation_count
+        allocation_count += 1
+        if allocation_count == 2:
+            raise OSError("simulated conflict allocation failure")
+        handle, path = original_mkstemp(*args, **kwargs)
+        created_paths.append(path)
+        return handle, path
+
+    monkeypatch.setattr(
+        "reacnetgenerator._step3state.tempfile.mkstemp",
+        fail_second_mkstemp,
+    )
+
+    with pytest.raises(OSError, match="simulated conflict allocation failure"):
+        _AtomFrameStore((3, 10), 4, directory=tmp_path)
+
+    assert allocation_count == 2
+    assert len(created_paths) == 1
+    assert not os.path.exists(created_paths[0])

--- a/tests/test_step3state.py
+++ b/tests/test_step3state.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Test compact temporary state used by Step 3."""
+
+import os
+
+import numpy as np
+import pytest
+
+from reacnetgenerator._step3state import (
+    _AtomFrameStore,
+    _MoleculeNameBuilder,
+    _unsigned_dtype_for_maximum,
+)
+
+
+@pytest.mark.parametrize(
+    ("maximum", "expected"),
+    [
+        (0, np.uint8),
+        (255, np.uint8),
+        (256, np.uint16),
+        (65535, np.uint16),
+        (65536, np.uint32),
+        (2**32, np.uint64),
+    ],
+)
+def test_unsigned_dtype_uses_narrowest_width(maximum, expected):
+    """Molecule IDs should use the narrowest lossless unsigned dtype."""
+    assert _unsigned_dtype_for_maximum(maximum) == np.dtype(expected)
+
+
+def test_unsigned_dtype_rejects_values_above_uint64():
+    """Unsupported molecule ID ranges should fail instead of wrapping."""
+    with pytest.raises(OverflowError, match="unsigned 64-bit"):
+        _unsigned_dtype_for_maximum(int(np.iinfo(np.uint64).max) + 1)
+
+
+def test_molecule_name_builder_deduplicates_species():
+    """Per-molecule IDs should index one copy of each species name."""
+    builder = _MoleculeNameBuilder(4)
+    for name in ("A", "B", "A", "C"):
+        builder.append(name)
+
+    table = builder.finish()
+
+    assert table.ids.dtype == np.dtype(np.uint8)
+    assert table.ids.tolist() == [0, 1, 0, 2]
+    assert table.names.tolist() == ["A", "B", "C"]
+    assert list(table) == ["A", "B", "A", "C"]
+    np.testing.assert_array_equal(table[np.array([3, 0, 2])], ["C", "A", "A"])
+    np.testing.assert_array_equal(np.asarray(table), ["A", "B", "A", "C"])
+
+
+def test_molecule_name_builder_checks_declared_count():
+    """Name-table construction should detect incomplete or excess records."""
+    incomplete = _MoleculeNameBuilder(1)
+    with pytest.raises(RuntimeError, match="Fewer molecule names"):
+        incomplete.finish()
+
+    excess = _MoleculeNameBuilder(1)
+    excess.append("A")
+    with pytest.raises(RuntimeError, match="More molecule names"):
+        excess.append("B")
+
+
+def test_atom_frame_store_is_compact_transposable_and_recoverable(tmp_path):
+    """Disk-backed matrices should retain ndarray semantics and clean up."""
+    with _AtomFrameStore((3, 10), 256, directory=tmp_path) as store:
+        atomeach_path = store.atomeach_path
+        conflict_path = store.conflict.path
+        assert store.atomeach.dtype == np.dtype(np.uint16)
+        assert store.atomeach.nbytes == 60
+        assert store.conflict.nbytes == 6
+        assert store.nbytes == 66
+
+        store.atomeach[0, [0, 8]] = 1
+        store.atomeach[1, [8, 9]] = 256
+        store.conflict.mark(
+            np.array([0, 1]),
+            np.array([0, 8, 9]),
+            np.array(
+                [
+                    [True, True, False],
+                    [False, True, True],
+                ]
+            ),
+        )
+        store.flush()
+
+        expected = np.zeros((3, 10), dtype=np.bool_)
+        expected[0, [0, 8]] = True
+        expected[1, [8, 9]] = True
+        np.testing.assert_array_equal(store.conflict, expected)
+        np.testing.assert_array_equal(store.conflict.T, expected.T)
+        np.testing.assert_array_equal(
+            tuple(store.conflict.T[8:10]),
+            tuple(expected.T[8:10]),
+        )
+
+    assert not os.path.exists(atomeach_path)
+    assert not os.path.exists(conflict_path)

--- a/tests/test_step3state.py
+++ b/tests/test_step3state.py
@@ -45,6 +45,7 @@ def test_molecule_name_builder_deduplicates_species():
     table = builder.finish()
 
     assert table.ids.dtype == np.dtype(np.uint8)
+    assert table.names.dtype == np.dtype(object)
     assert table.ids.tolist() == [0, 1, 0, 2]
     assert table.names.tolist() == ["A", "B", "C"]
     assert list(table) == ["A", "B", "A", "C"]


### PR DESCRIPTION
## Summary

- store the Step 3 atom-to-molecule matrix in a disk-backed memmap using the narrowest lossless unsigned integer dtype
- bit-pack the conflict matrix and expose a lazy frame-major view to reaction analysis
- deduplicate molecule names through a compact molecule-ID-to-species table with variable-length object strings
- clean up temporary mappings on normal completion, input errors, and partial allocation failures
- keep HMM records aligned with retained origin metadata, including all-zero filtered signals
- prefer output-adjacent scratch storage and retry in the default temporary directory on `PermissionError`, allowing destinations such as `/dev/null`

## Motivation

Current master keeps dense `int32` atom-to-molecule and Boolean conflict matrices in memory. These arrays require about `5 * N * step` bytes, before multiprocessing and temporary-array overhead. Large atom/frame combinations can therefore exhaust memory even with bounded result delivery.

This change reduces the representation size and moves atom-frame storage from heap arrays to disk-backed mappings. Memory-mapped pages can still consume resident memory and page cache. Output formats and public CLI options remain unchanged.

Strict stream pairing is retained. When origin output keeps a filtered molecule's metadata, the HMM producer now writes the corresponding zero signal rather than leaving the streams misaligned.

## Validation

- 22 focused tests passed: `tests/test_step3_compatibility.py`, `tests/test_step3state.py`, and the existing conflict-index, mismatched-stream, compact-reaction-event, packed-conflict, object-name reaction-matrix, and VF2/SMILES selective-output regression tests.
- The HMM/origin regression compares atom routes and both reaction outputs byte-for-byte with origin output disabled; the fixture is checked to contain filtered molecules.
- Permission-fallback tests inject failures at both the first and second preferred allocation and verify fallback contents and cleanup.
- Four bounded smoke cases passed: HMM/SMILES with split output, no-HMM/VF2, no-HMM/miso, and atom-route output to `/dev/null`. Each retained the checked-in reaction SHA-256.
- Four targeted upstream component-guard tests passed.
- Ruff 0.16.4 lint and format checks passed for all seven PR Python files.
- ty 0.0.15 passed for the three changed production modules; `git diff --check` passed.

Local runs used Python 3.12, the worktree Python sources, existing native dependency extensions, and one worker per trajectory case. GitHub Actions on `9ca3a00f` also passed: tox reported 176 passed, 6 xfailed, and 4 xpassed; all wheel builds, static checks, coverage, docs, and performance checks succeeded. Publication/deployment jobs were skipped. CodeRabbit returned a successful status with a rate-limit notice rather than a fresh full review.

## Scope

The branch includes current master through `01e1f331`, retaining its component guards and independent bounded-analysis changes. The compact representations replace the overlapping dense-state changes.

Atom-frame state remains proportional to `N x step` on disk. Remaining Step 3 scans and per-task copies are outside this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved reaction-path processing for large datasets with more compact, disk-backed temporary storage.
  * Reduced memory usage for molecule names, atom-frame data, and conflict information.
  * Added automatic cleanup of temporary processing data, including after errors.
  * Improved detection of incomplete or mismatched reaction records.
  * Preserved reaction-event results while handling atom-frame conflicts more reliably.

* **Tests**
  * Expanded coverage for compact storage, data types, transposition, cleanup, conflict handling, and large-value scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

