### PR TITLE
feat: support explicit output directories

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -13,8 +13,10 @@ prog: reacnetgenerator
 Pass --output-dir to keep all default-generated artifacts for one run in an
 independent directory. The input basename is not used to distinguish outputs.
 
-    reacnetgenerator --type dump -i trajectory.lammpstrj -a C H O \
-        --nohmm --output-dir artifacts
+```
+reacnetgenerator --type dump -i trajectory.lammpstrj -a C H O \
+    --nohmm --output-dir artifacts
+```
 
 The option changes only default output paths; explicit filename arguments remain
 authoritative for backward compatibility.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -7,3 +7,14 @@ func: main_parser
 prog: reacnetgenerator
 ---
 ```
+
+## Explicit output directory
+
+Pass --output-dir to keep all default-generated artifacts for one run in an
+independent directory. The input basename is not used to distinguish outputs.
+
+    reacnetgenerator --type dump -i trajectory.lammpstrj -a C H O \
+        --nohmm --output-dir artifacts
+
+The option changes only default output paths; explicit filename arguments remain
+authoritative for backward compatibility.

--- a/docs/guide/python.md
+++ b/docs/guide/python.md
@@ -18,3 +18,23 @@ See {class}`ReacNetGenerator <reacnetgenerator.ReacNetGenerator>` class for deta
 ## Calculate rate constants
 
 An effiective tool is provided in {meth}`reacnetgenerator.tools.calculate_rate <reacnetgenerator.tools.calculate_rate>` to calculate rate constants.
+
+## Explicit output directory
+
+The convenience API returns semantic artifact paths and writes its default
+outputs below the requested directory.
+
+    from reacnetgenerator import run
+
+    artifacts = run(
+        input_path="trajectory.lammpstrj",
+        output_dir="artifacts",
+        input_type="dump",
+        atomname=["C", "H", "O"],
+        items=("species", "reactions", "network", "report"),
+        runHMM=False,
+    )
+    print(artifacts["species"])
+
+The existing ReacNetGenerator class accepts the same output_dir keyword and
+exposes the mapping as generator.artifacts.

--- a/docs/guide/python.md
+++ b/docs/guide/python.md
@@ -24,17 +24,19 @@ An effiective tool is provided in {meth}`reacnetgenerator.tools.calculate_rate <
 The convenience API returns semantic artifact paths and writes its default
 outputs below the requested directory.
 
-    from reacnetgenerator import run
+```
+from reacnetgenerator import run
 
-    artifacts = run(
-        input_path="trajectory.lammpstrj",
-        output_dir="artifacts",
-        input_type="dump",
-        atomname=["C", "H", "O"],
-        items=("species", "reactions", "network", "report"),
-        runHMM=False,
-    )
-    print(artifacts["species"])
+artifacts = run(
+    input_path="trajectory.lammpstrj",
+    output_dir="artifacts",
+    input_type="dump",
+    atomname=["C", "H", "O"],
+    items=("species", "reactions", "network", "report"),
+    runHMM=False,
+)
+print(artifacts["species"])
+```
 
 The existing ReacNetGenerator class accepts the same output_dir keyword and
 exposes the mapping as generator.artifacts.

--- a/reacnetgenerator/__init__.py
+++ b/reacnetgenerator/__init__.py
@@ -37,4 +37,56 @@ class ReacNetGenerator:
 if TYPE_CHECKING:
     from .reacnetgen import ReacNetGenerator
 
-__all__ = ["ReacNetGenerator", "__version__"]
+def run(
+    *,
+    input_path,
+    output_dir,
+    input_type,
+    atomname,
+    items=("species", "reactions", "network", "report"),
+    **kwargs,
+):
+    """Run ReacNetGenerator and return semantic artifact paths.
+
+    Parameters
+    ----------
+    input_path : str or pathlib.Path or sequence
+        Input trajectory or bond file(s).
+    output_dir : str or pathlib.Path
+        Directory receiving all default-generated artifacts.
+    input_type : str
+        ReacNetGenerator input type, such as "dump" or "bond".
+    atomname : sequence of str
+        Element names in the input trajectory.
+    items : sequence of str, optional
+        Requested stages. "species" and "reactions" are produced by
+        the core run; "network" and "report" control the optional
+        drawing/report stages.
+    **kwargs
+        Additional arguments forwarded to ReacNetGenerator.
+    """
+    if isinstance(items, str):
+        items = (items,)
+    requested = set(items)
+    allowed = {"species", "reactions", "network", "report"}
+    unknown = requested - allowed
+    if unknown:
+        raise ValueError(f"Unsupported output items: {sorted(unknown)}")
+    if not requested:
+        raise ValueError("items must contain at least one output stage")
+
+    generator = ReacNetGenerator(
+        inputfilename=input_path,
+        output_dir=output_dir,
+        inputfiletype=input_type,
+        atomname=atomname,
+        **kwargs,
+    )
+    return generator.runanddraw(
+        run=True,
+        draw="network" in requested,
+        report="report" in requested,
+    )
+
+
+__all__ = ["ReacNetGenerator", "__version__", "run"]

--- a/reacnetgenerator/__init__.py
+++ b/reacnetgenerator/__init__.py
@@ -37,6 +37,7 @@ class ReacNetGenerator:
 if TYPE_CHECKING:
     from .reacnetgen import ReacNetGenerator
 
+
 def run(
     *,
     input_path,

--- a/reacnetgenerator/__init__.py
+++ b/reacnetgenerator/__init__.py
@@ -76,7 +76,9 @@ def run(
     if not requested:
         raise ValueError("items must contain at least one output stage")
 
-    generator = ReacNetGenerator(
+    from .reacnetgen import ReacNetGenerator as RealRNG
+
+    generator = RealRNG(
         inputfilename=input_path,
         output_dir=output_dir,
         inputfiletype=input_type,

--- a/reacnetgenerator/__init__.py
+++ b/reacnetgenerator/__init__.py
@@ -41,9 +41,9 @@ if TYPE_CHECKING:
 def run(
     *,
     input_path,
-    output_dir,
     input_type,
     atomname,
+    output_dir=None,
     items=("species", "reactions", "network", "report"),
     **kwargs,
 ):
@@ -85,7 +85,7 @@ def run(
     )
     return generator.runanddraw(
         run=True,
-        draw="network" in requested,
+        draw="network" in requested or "report" in requested,
         report="report" in requested,
     )
 

--- a/reacnetgenerator/_draw.py
+++ b/reacnetgenerator/_draw.py
@@ -23,6 +23,7 @@ References
 import math
 from io import StringIO
 from itertools import permutations
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -143,8 +144,11 @@ class _DrawNetwork(SharedRNGData):
                     edge_color=colors,
                     node_color=[self.node_color] * len(pos),
                 )
-                imagefilename = "".join(
-                    (("" if with_labels else "nolabel_"), self.imagefilename)
+                image_path = Path(self.imagefilename)
+                imagefilename = str(
+                    image_path.with_name(
+                        ("" if with_labels else "nolabel_") + image_path.name
+                    )
                 )
                 with (
                     StringIO() as stringio,

--- a/reacnetgenerator/commandline.py
+++ b/reacnetgenerator/commandline.py
@@ -69,6 +69,10 @@ def main_parser() -> argparse.ArgumentParser:
         required=True,
     )
     parser.add_argument(
+        "--output-dir",
+        help="Write generated artifacts below this directory using semantic filenames.",
+    )
+    parser.add_argument(
         "--nohmm",
         help=(
             "Process trajectory without Hidden Markov Model (HMM). If one wants to enable HMM, firstly "
@@ -256,6 +260,7 @@ def _commandline():
     rng = ReacNetGenerator(
         inputfilename=args.inputfilename,
         atomname=args.atomname,
+        output_dir=args.output_dir,
         miso=args.miso,
         runHMM=not args.nohmm,
         inputfiletype=("lammpsdumpfile" if args.dump else args.type),
@@ -302,6 +307,8 @@ def parm2cmd(pp: dict) -> list[str]:
         Command line arguments
     """
     commands = ["reacnetgenerator", "-i", pp["inputfilename"], "-a", *pp["atomname"]]
+    if pp.get("output_dir"):
+        commands.extend(("--output-dir", str(pp["output_dir"])))
     if not pp.get("runHMM", True):
         commands.append("--nohmm")
     if pp["inputfiletype"]:

--- a/reacnetgenerator/reacnetgen.py
+++ b/reacnetgenerator/reacnetgen.py
@@ -48,6 +48,7 @@ import itertools
 import os
 import time
 from enum import Enum
+from pathlib import Path
 from typing import Any, ClassVar
 
 import numpy as np
@@ -193,6 +194,7 @@ class ReacNetGenerator:
             "custom_cutoffs": None,
             "max_component_atoms": 256,
             "max_component_fraction": 0.1,
+            "output_dir": None,
         }
         none_key = [
             "selectatoms",
@@ -254,8 +256,19 @@ class ReacNetGenerator:
                 kwargs[kk] = default_value[kk]
         for kk in itertools.chain(none_key, accept_keys):
             kwargs.setdefault(kk, None)
+        output_dir = kwargs.get("output_dir")
+        output_path = None
+        if output_dir is not None:
+            output_path = Path(output_dir).expanduser()
+            output_path.mkdir(parents=True, exist_ok=True)
+            kwargs["output_dir"] = str(output_path)
         for kk in file_key:
-            kwargs.setdefault(kk, f"{kwargs['inputfilename'][0]}.{file_key[kk]}")
+            default_filename = (
+                str(output_path / file_key[kk])
+                if output_path is not None
+                else f"{kwargs['inputfilename'][0]}.{file_key[kk]}"
+            )
+            kwargs.setdefault(kk, default_filename)
         for kk in nparray_key:
             kwargs[kk] = np.array(kwargs[kk])
         max_component_atoms = kwargs["max_component_atoms"]
@@ -315,6 +328,23 @@ class ReacNetGenerator:
                 self.cell = cell.reshape((3, 3))
             else:
                 raise RuntimeError(cell_error)
+        self.artifacts = self._build_artifact_map()
+
+    def _build_artifact_map(self) -> dict[str, str]:
+        """Return the semantic artifact paths for this analysis."""
+        return {
+            "moname": self.moleculefilename,
+            "molecules": self.moleculetimelinefilename,
+            "route": self.atomroutefilename,
+            "reactions": self.reactionfilename,
+            "table": self.tablefilename,
+            "network": self.imagefilename,
+            "species": self.speciesfilename,
+            "report": self.resultfilename,
+            "json": self.jsonfilename,
+            "reactionabcd": self.reactionabcdfilename,
+            "reactionevent": self.reactioneventfilename,
+        }
 
     @staticmethod
     def _normalize_optional_int_filter(value):
@@ -415,7 +445,7 @@ class ReacNetGenerator:
     # ------------------------------------------------------------------
     def runanddraw(
         self, run: bool = True, draw: bool = True, report: bool = True
-    ) -> None:
+    ) -> dict[str, str]:
         """Analyze the trajectory from MD simulation.
 
         Parameters
@@ -444,8 +474,9 @@ class ReacNetGenerator:
         if report:
             processthing.append(self.Status.REPORT)
         self._process(processthing)
+        return dict(self.artifacts)
 
-    def run(self) -> None:
+    def run(self) -> dict[str, str]:
         """Process MD trajectory, including DOWNLOAD, DETECT, HMM, PATH, and MATRIX steps."""
         processthing = []
         if self.urls:
@@ -459,6 +490,7 @@ class ReacNetGenerator:
             )
         )
         self._process(processthing)
+        return dict(self.artifacts)
 
     def draw(self) -> None:
         """Draw the reaction network, i.e. NETWORK step."""

--- a/reacnetgenerator/reacnetgen.py
+++ b/reacnetgenerator/reacnetgen.py
@@ -143,7 +143,18 @@ class ReacNetGenerator:
     moleculetemp2filename: str
     originfilename: str
     hmmfilename: str
+    # Output paths are populated from normalized constructor kwargs.
+    moleculefilename: str
+    moleculetimelinefilename: str
+    atomroutefilename: str
+    reactionfilename: str
+    tablefilename: str
+    imagefilename: str
+    speciesfilename: str
     resultfilename: str
+    jsonfilename: str
+    reactionabcdfilename: str
+    reactioneventfilename: str
 
     def __init__(self, **kwargs: Any) -> None:
         """Init ReacNetGenerator."""

--- a/tests/test_output_dir.py
+++ b/tests/test_output_dir.py
@@ -81,4 +81,6 @@ def test_run_wrapper_returns_artifacts_without_running(tmp_path, monkeypatch):
         atomname=["H"],
         items=("species", "network"),
     )
-    assert artifacts["report"].endswith("/html") or artifacts["report"].endswith("\\html")
+    assert artifacts["report"].endswith("/html") or artifacts["report"].endswith(
+        "\\html"
+    )

--- a/tests/test_output_dir.py
+++ b/tests/test_output_dir.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+"""Tests for explicit output-directory contracts."""
+
+from pathlib import Path
+
+import pytest
+
+from reacnetgenerator import ReacNetGenerator, run
+from reacnetgenerator.commandline import main_parser, parm2cmd
+
+
+def test_output_dir_maps_default_artifacts(tmp_path):
+    output_dir = tmp_path / "artifacts"
+    generator = ReacNetGenerator(
+        inputfilename=str(tmp_path / "trajectory.dump"),
+        inputfiletype="dump",
+        atomname=["H"],
+        output_dir=output_dir,
+    )
+
+    assert output_dir.is_dir()
+    assert generator.artifacts["species"] == str(output_dir / "species")
+    assert generator.artifacts["reactions"] == str(output_dir / "reaction")
+    assert generator.artifacts["network"] == str(output_dir / "svg")
+    assert all(Path(path).parent == output_dir for path in generator.artifacts.values())
+
+
+def test_output_dir_is_optional_and_preserves_legacy_names(tmp_path):
+    input_path = tmp_path / "trajectory.dump"
+    generator = ReacNetGenerator(
+        inputfilename=str(input_path),
+        inputfiletype="dump",
+        atomname=["H"],
+    )
+
+    assert generator.speciesfilename == f"{input_path}.species"
+    assert Path(generator.artifacts["species"]).parent == tmp_path
+
+
+def test_cli_and_parm2cmd_expose_output_dir(tmp_path):
+    output_dir = tmp_path / "artifacts"
+    parser = main_parser()
+    args = parser.parse_args(
+        ["-i", "trajectory.dump", "-a", "H", "--output-dir", str(output_dir)]
+    )
+    assert args.output_dir == str(output_dir)
+    command = parm2cmd(
+        {
+            "inputfilename": "trajectory.dump",
+            "atomname": ["H"],
+            "inputfiletype": "dump",
+            "output_dir": output_dir,
+        }
+    )
+    assert command[-2:] == ["--output-dir", str(output_dir)]
+
+
+def test_run_rejects_unknown_items(tmp_path):
+    with pytest.raises(ValueError, match="Unsupported output items"):
+        run(
+            input_path="trajectory.dump",
+            output_dir=tmp_path / "artifacts",
+            input_type="dump",
+            atomname=["H"],
+            items=("species", "unknown"),
+        )
+
+
+def test_run_wrapper_returns_artifacts_without_running(tmp_path, monkeypatch):
+    def fake_runanddraw(self, *, run, draw, report):
+        assert (run, draw, report) == (True, True, False)
+        return dict(self.artifacts)
+
+    monkeypatch.setattr(
+        "reacnetgenerator.reacnetgen.ReacNetGenerator.runanddraw", fake_runanddraw
+    )
+    artifacts = run(
+        input_path="trajectory.dump",
+        output_dir=tmp_path / "artifacts",
+        input_type="dump",
+        atomname=["H"],
+        items=("species", "network"),
+    )
+    assert artifacts["report"].endswith("/html") or artifacts["report"].endswith("\\html")

--- a/tests/test_output_dir.py
+++ b/tests/test_output_dir.py
@@ -10,6 +10,7 @@ from reacnetgenerator.commandline import main_parser, parm2cmd
 
 
 def test_output_dir_maps_default_artifacts(tmp_path):
+    """Map default artifact names below an explicit output directory."""
     output_dir = tmp_path / "artifacts"
     generator = ReacNetGenerator(
         inputfilename=str(tmp_path / "trajectory.dump"),
@@ -26,6 +27,7 @@ def test_output_dir_maps_default_artifacts(tmp_path):
 
 
 def test_output_dir_is_optional_and_preserves_legacy_names(tmp_path):
+    """Keep basename-derived artifact paths when output_dir is omitted."""
     input_path = tmp_path / "trajectory.dump"
     generator = ReacNetGenerator(
         inputfilename=str(input_path),
@@ -38,6 +40,7 @@ def test_output_dir_is_optional_and_preserves_legacy_names(tmp_path):
 
 
 def test_cli_and_parm2cmd_expose_output_dir(tmp_path):
+    """Round-trip output_dir through CLI parsing and command rebuilding."""
     output_dir = tmp_path / "artifacts"
     parser = main_parser()
     args = parser.parse_args(
@@ -52,10 +55,11 @@ def test_cli_and_parm2cmd_expose_output_dir(tmp_path):
             "output_dir": output_dir,
         }
     )
-    assert command[-2:] == ["--output-dir", str(output_dir)]
+    assert parser.parse_args(command[1:]).output_dir == str(output_dir)
 
 
 def test_run_rejects_unknown_items(tmp_path):
+    """Reject unsupported semantic output items."""
     with pytest.raises(ValueError, match="Unsupported output items"):
         run(
             input_path="trajectory.dump",
@@ -67,6 +71,8 @@ def test_run_rejects_unknown_items(tmp_path):
 
 
 def test_run_wrapper_returns_artifacts_without_running(tmp_path, monkeypatch):
+    """Return the generator artifact mapping from the run convenience API."""
+
     def fake_runanddraw(self, *, run, draw, report):
         assert (run, draw, report) == (True, True, False)
         return dict(self.artifacts)
@@ -84,3 +90,65 @@ def test_run_wrapper_returns_artifacts_without_running(tmp_path, monkeypatch):
     assert artifacts["report"].endswith("/html") or artifacts["report"].endswith(
         "\\html"
     )
+
+
+def test_run_wrapper_preserves_legacy_paths_without_output_dir(tmp_path, monkeypatch):
+    """Let the convenience API omit output_dir without changing legacy paths."""
+
+    def fake_runanddraw(self, *, run, draw, report):
+        assert (run, draw, report) == (True, False, False)
+        return dict(self.artifacts)
+
+    monkeypatch.setattr(
+        "reacnetgenerator.reacnetgen.ReacNetGenerator.runanddraw", fake_runanddraw
+    )
+    input_path = tmp_path / "trajectory.dump"
+    artifacts = run(
+        input_path=input_path,
+        input_type="dump",
+        atomname=["H"],
+        items=("species",),
+    )
+    assert artifacts["species"] == f"{input_path}.species"
+
+
+def test_run_report_includes_network_dependency(tmp_path, monkeypatch):
+    """Request network generation whenever an HTML report is requested."""
+
+    def fake_runanddraw(self, *, run, draw, report):
+        assert (run, draw, report) == (True, True, True)
+        return dict(self.artifacts)
+
+    monkeypatch.setattr(
+        "reacnetgenerator.reacnetgen.ReacNetGenerator.runanddraw", fake_runanddraw
+    )
+    run(
+        input_path="trajectory.dump",
+        output_dir=tmp_path / "artifacts",
+        input_type="dump",
+        atomname=["H"],
+        items=("report",),
+    )
+
+
+def test_nolabel_network_stays_inside_output_dir(tmp_path, monkeypatch):
+    """Prefix only the image basename for unlabeled network output."""
+    from reacnetgenerator._draw import _DrawNetwork
+
+    output_dir = tmp_path / "artifacts"
+    generator = ReacNetGenerator(
+        inputfilename="trajectory.dump",
+        inputfiletype="dump",
+        atomname=["H"],
+        output_dir=output_dir,
+        nolabel=True,
+    )
+    drawer = _DrawNetwork(generator)
+    monkeypatch.setattr(drawer, "_readtable", lambda _: ([[0]], ["H"]))
+    monkeypatch.setattr(drawer, "_handlespecies", lambda names: (names, {"H": "H"}))
+
+    drawer._draw()
+
+    assert (output_dir / "svg").is_file()
+    assert (output_dir / "nolabel_svg").is_file()
+    assert not (tmp_path / "nolabel_artifacts").exists()

--- a/tests/test_output_dir.py
+++ b/tests/test_output_dir.py
@@ -70,6 +70,17 @@ def test_run_rejects_unknown_items(tmp_path):
         )
 
 
+def test_run_rejects_empty_items():
+    """Reject an empty semantic output request."""
+    with pytest.raises(ValueError, match="at least one output stage"):
+        run(
+            input_path="trajectory.dump",
+            input_type="dump",
+            atomname=["H"],
+            items=(),
+        )
+
+
 def test_run_wrapper_returns_artifacts_without_running(tmp_path, monkeypatch):
     """Return the generator artifact mapping from the run convenience API."""
 


### PR DESCRIPTION
## Summary

- add output_dir to the Python class API and CLI
- keep legacy basename-derived paths unchanged when the option is omitted
- expose semantic artifact paths through generator.artifacts and reacnetgenerator.run
- add contract tests and user documentation

Fixes #2490

## Verification

- git diff --check
- Python bytecode compilation
- output-dir API/CLI contract smoke test with the ReacNet C-extension stubbed
- Full pytest remains pending in the remote environment because pytest and the
  compiled reacnetgenerator.dps extension are not installed there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--output-dir` CLI option to place generated artifacts in a dedicated directory.
  * Added a Python `run()` API with selectable output stages and artifact paths.
  * Added configurable limits for component atom counts and size fractions.
  * Results now include parameter provenance for reproducibility.
  * Explicit filenames continue to take precedence for compatibility.
  * Unsupported or empty stage selections are rejected with a clear error.

* **Bug Fixes**
  * Corrected image output naming when labels are hidden, preserving the configured directory.

* **Documentation**
  * Added CLI and Python guidance for output directories, artifact paths, and provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->